### PR TITLE
Potential fix for code scanning alert no. 80: Uncontrolled data used in path expression

### DIFF
--- a/tools/mobile/android/android_gui.py
+++ b/tools/mobile/android/android_gui.py
@@ -565,7 +565,9 @@ class _Handler(BaseHTTPRequestHandler):
         import base64
         serial  = body.get("device", "")
         b64     = body.get("data", "")
-        ext     = body.get("ext", "mp3")
+        ext     = str(body.get("ext", "mp3")).strip().lower()
+        if ext not in {"mp3", "wav"}:
+            self._json({"ok": False, "error": "invalid audio extension"}); return
         prefix  = (["-s", serial] if serial else [])
         adb     = shutil.which("adb") or "adb"
         if not b64:


### PR DESCRIPTION
Potential fix for [https://github.com/secvulnhub/SecV/security/code-scanning/80](https://github.com/secvulnhub/SecV/security/code-scanning/80)

Use strict allowlist validation for `ext` before it is used in any path expression.  
Best fix here: normalize to lowercase string and only permit known safe extensions actually supported by this endpoint (`mp3`, `wav`). Reject anything else with a clear JSON error and return early. This preserves functionality while removing path-taint to the sink.

In `tools/mobile/android/android_gui.py`, edit `_api_speaker` (around lines 563–583):
- Replace direct `ext = body.get("ext", "mp3")` usage with:
  - `ext = str(body.get("ext", "mp3")).strip().lower()`
  - allowlist check (`{"mp3", "wav"}`)
  - early error response if invalid.
- Keep existing behavior for valid values, including MIME selection and file naming.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
