### PR TITLE
Potential fix for code scanning alert no. 77: Uncontrolled command line

### DIFF
--- a/tools/mobile/android/android_gui.py
+++ b/tools/mobile/android/android_gui.py
@@ -563,7 +563,9 @@ class _Handler(BaseHTTPRequestHandler):
     def _api_speaker(self, body: dict):
         """Push a base64-encoded audio file to the device and play it."""
         import base64
-        serial  = body.get("device", "")
+        serial  = str(body.get("device", "")).strip()
+        if serial and not re.fullmatch(r"[A-Za-z0-9._:-]+", serial):
+            self._json({"ok": False, "error": "invalid device serial"}); return
         b64     = body.get("data", "")
         ext     = str(body.get("ext", "mp3")).strip().lower()
         if ext not in {"mp3", "wav"}:


### PR DESCRIPTION
Potential fix for [https://github.com/secvulnhub/SecV/security/code-scanning/77](https://github.com/secvulnhub/SecV/security/code-scanning/77)

General fix approach: ensure all user-controlled command arguments are validated against a strict allowlist pattern before being passed to `subprocess.run`. Reject invalid input early and return an error response.

Best fix here (without changing functionality): in `tools/mobile/android/android_gui.py`, inside `_api_speaker`, validate `serial` immediately after reading it from `body`. Allow empty serial (current behavior) or a constrained Android-serial-safe pattern (letters, digits, `.`, `_`, `:`, `-`). If invalid, return JSON error and do not execute adb. This keeps existing behavior for valid devices, while blocking unsafe/unexpected values and satisfying CodeQL taint flow concerns.

No new imports are needed since `re` is already imported at file top.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
